### PR TITLE
Add support for WeMo Insight.

### DIFF
--- a/WeMoSocketBridge.js
+++ b/WeMoSocketBridge.js
@@ -67,9 +67,7 @@ WeMoSocketBridge.prototype.discover = function () {
     var cp = iotdb.module("iotdb-upnp").control_point();
 
     cp.on("device", function (native) {
-        if (native.deviceType !== "urn:Belkin:device:controllee:1") {
-            return;
-        } else if (native.modelName !== "Socket") {
+        if (!self.isSupported(native)) {
             return;
         }
 
@@ -78,6 +76,18 @@ WeMoSocketBridge.prototype.discover = function () {
 
     cp.search();
 
+};
+
+/**
+ *  Check if the detected device is supported by this socket
+ */
+WeMoSocketBridge.prototype.isSupported = function (native) {
+    return (
+        (native.deviceType == "urn:Belkin:device:controllee:1" &&
+        native.modelName == "Socket") ||
+        (native.deviceType == "urn:Belkin:device:insight:1" &&
+        native.modelName == "Insight")
+    );
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,36 +1,36 @@
 {
-    "author": "David P. Janes <davidjanes@iotdb.org> (https://iotdb.org)", 
+    "author": "David P. Janes <davidjanes@iotdb.org> (https://iotdb.org)",
     "bugs": {
         "url": "https://github.com/dpjanes/homestar-wemo/issues"
-    }, 
+    },
     "dependencies": {
-        "iotdb": ">=0.4.16", 
+        "iotdb": ">=0.4.16",
         "iotdb-upnp": ">=0.0.1"
-    }, 
-    "description": "HomeStar / IOTDB Bridge for Belkin WeMo", 
+    },
+    "description": "HomeStar / IOTDB Bridge for Belkin WeMo",
     "devDependencies": {
-        "grunt": "~0.4.5", 
-        "grunt-contrib-jshint": "~0.10.0", 
-        "grunt-contrib-nodeunit": "~0.2.0", 
-        "grunt-contrib-uglify": "~0.5.0", 
-        "grunt-contrib-watch": "~0.5.0", 
-        "grunt-jsbeautifier": "^0.2.7", 
-        "jshint-stylish": "~0.1.3", 
-        "load-grunt-tasks": "~0.2.0", 
+        "grunt": "~0.4.5",
+        "grunt-contrib-jshint": "~0.10.0",
+        "grunt-contrib-nodeunit": "~0.2.0",
+        "grunt-contrib-uglify": "~0.5.0",
+        "grunt-contrib-watch": "~0.5.0",
+        "grunt-jsbeautifier": "^0.2.7",
+        "jshint-stylish": "~0.1.3",
+        "load-grunt-tasks": "~0.2.0",
         "request": "^2.36.0"
-    }, 
-    "homepage": "https://homestar.io", 
-    "homestar": {}, 
-    "license": "Apache-2.0", 
-    "main": "index.js", 
-    "name": "homestar-wemo", 
-    "private": false, 
+    },
+    "homepage": "https://homestar.io",
+    "homestar": {},
+    "license": "Apache-2.0",
+    "main": "index.js",
+    "name": "homestar-wemo",
+    "private": false,
     "repository": {
-        "type": "git", 
+        "type": "git",
         "url": "https://github.com/dpjanes/homestar-wemo"
-    }, 
+    },
     "scripts": {
         "test": "grunt"
-    }, 
-    "version": "0.0.5"
+    },
+    "version": "0.0.6"
 }


### PR DESCRIPTION
@dpjanes  It is a quick patch for adding support of WeMo Insight. I dont know if a new Bridge is required since WeMo Insight provided some other features than WeMo Switch like consuming report:

```
<service>
<serviceType>urn:Belkin:service:insight:1</serviceType>
<serviceId>urn:Belkin:serviceId:insight1</serviceId>
<controlURL>/upnp/control/insight1</controlURL>
<eventSubURL>/upnp/event/insight1</eventSubURL>
<SCPDURL>/insightservice.xml</SCPDURL>
</service>
```

and other stuff.
